### PR TITLE
Removed asset-packagist from composer repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,6 @@
             "type": "composer",
             "url": "https://packagist.orocrm.com"
         },
-        "asset-packagist": {
-            "type": "composer",
-            "url": "https://asset-packagist.orocrm.com"
-        },
         "marello" :{
             "type": "vcs",
             "url": "https://github.com/marellocommerce/marello.git",

--- a/dev.json
+++ b/dev.json
@@ -22,10 +22,6 @@
             "type": "composer",
             "url": "https://packagist.orocrm.com"
         },
-        "asset-packagist": {
-            "type": "composer",
-            "url": "https://asset-packagist.orocrm.com"
-        },
         "local-packages": {
             "type": "path",
             "url": "../../package/*"


### PR DESCRIPTION
 - it's not used anymore in oro/platform:4.1+
 - all the nodejs dependencies should be managed with npm, see https://doc.oroinc.com/frontend/javascript/composer-js-dependencies/