### PR TITLE
Fix use reference

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 
 // if you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information


### PR DESCRIPTION
The file for `bin/console` contains a use reference for an older version of Symfony. This should be changed to make it compatible with Symfony 5.x.